### PR TITLE
Fix support of different directories.

### DIFF
--- a/gym_recording/wrappers/trace_recording.py
+++ b/gym_recording/wrappers/trace_recording.py
@@ -58,7 +58,7 @@ class TraceRecordingWrapper(gym.Wrapper):
         self.recording = None
         trace_record_closer.register(self)
 
-        self.recording = TraceRecording(None)
+        self.recording = TraceRecording(directory)
         self.directory = self.recording.directory
 
     def _step(self, action):


### PR DESCRIPTION
Instead of initialising with `None`, use the actually supplied directory. 