### PR TITLE
Gym-recording Compatibility with Newest version of OpenAI Gym (Plus some bugs fixed)

### DIFF
--- a/gym_recording/recording.py
+++ b/gym_recording/recording.py
@@ -108,7 +108,7 @@ class TraceRecording(object):
             'fn': batch_fn})
 
         manifest = {'batches': self.batches}
-        manifest_fn = os.path.join(self.directory, '{}.manifest.json'.format(self.file_prefix))
+        manifest_fn = '{}.manifest.json'.format(self.file_prefix)
         with atomic_write.atomic_write(os.path.join(self.directory, manifest_fn), False) as f:
             json.dump(manifest, f)
 

--- a/gym_recording/wrappers/trace_recording.py
+++ b/gym_recording/wrappers/trace_recording.py
@@ -57,8 +57,8 @@ class TraceRecordingWrapper(gym.Wrapper):
         super(TraceRecordingWrapper, self).__init__(env)
         self.recording = None
         trace_record_closer.register(self)
-
-        self.recording = TraceRecording(None)
+        
+        self.recording = TraceRecording(directory)
         self.directory = self.recording.directory
 
     def _step(self, action):

--- a/gym_recording/wrappers/trace_recording.py
+++ b/gym_recording/wrappers/trace_recording.py
@@ -61,12 +61,12 @@ class TraceRecordingWrapper(gym.Wrapper):
         self.recording = TraceRecording(directory)
         self.directory = self.recording.directory
 
-    def _step(self, action):
+    def step(self, action):
         observation, reward, done, info = self.env.step(action)
         self.recording.add_step(action, observation, reward)
         return observation, reward, done, info
 
-    def _reset(self):
+    def reset(self):
         self.recording.end_episode()
         observation = self.env.reset()
         self.recording.add_reset(observation)


### PR DESCRIPTION
Dear developers,

In the newest version of OpenAI gym, `_step` and `_reset` functions are not present. Therefore, I had to change the name of these functions in your source code to `reset` and `step` to make it compatible with the newest version of the OpenAI gym.

Also, when the directory argument would be passed to TraceRecordingWrapper, no changes to self.directory would be made. So, I've done some minor changes to your source code to make sure that we can pass customized directory names to this class.

At last, there was a minor bug with saving the manifest saving path that has been resolved.

Best,
Erfan